### PR TITLE
Update Chart to use perfectra1n/volsync images.

### DIFF
--- a/helm/volsync/README.md
+++ b/helm/volsync/README.md
@@ -91,7 +91,7 @@ on the command line or via a custom `values.yaml` file.
 - `replicaCount`: `1`
   - The number of replicas of the operator to run. Only one is active at a time,
     controlled via leader election.
-- `image.repository`: `quay.io/backube/volsync`
+- `image.repository`: `ghcr.io/perfectra1n/volsync`
   - The container image of the VolSync operator
 - `image.pullPolicy`: `IfNotPresent`
   - The image pull policy to apply to the operator's image
@@ -101,26 +101,26 @@ on the command line or via a custom `values.yaml` file.
 - `image.image`: (empty)
   - Allows overriding the repository & tag as a single field to support
     specifying a specific container version by hash (e.g.,
-    `quay.io/backube/volsync@sha256:XXXXXXX`).
-- `rclone.repository`: `quay.io/backube/volsync-mover-rclone`
+    `ghcr.io/perfectra1n/volsync@sha256:XXXXXXX`).
+- `rclone.repository`: `ghcr.io/perfectra1n/volsync`
   - The container image for VolSync's rclone-based data mover
 - `rclone.tag`: (current appVersion)
   - The tag to use for the rclone-based data mover
 - `rclone.image`: (empty)
   - Allows overriding the repository & tag as a single field.
-- `restic.repository`: `quay.io/backube/volsync-mover-restic`
+- `restic.repository`: `ghcr.io/perfectra1n/volsync`
   - The container image for VolSync's restic-based data mover
 - `restic.tag`: (current appVersion)
   - The tag to use for the restic-based data mover
 - `restic.image`: (empty)
   - Allows overriding the repository & tag as a single field.
-- `rsync.repository`: `quay.io/backube/volsync-mover-rsync`
+- `rsync.repository`: `ghcr.io/perfectra1n/volsync`
   - The container image for VolSync's rsync-based data mover
 - `rsync.tag`: (current appVersion)
   - The tag to use for the rsync-based data mover
 - `rsync.image`: (empty)
   - Allows overriding the repository & tag as a single field.
-- `rsync-tls.repository`: `quay.io/backube/volsync-mover-rsync-tls`
+- `rsync-tls.repository`: `ghcr.io/perfectra1n/volsync`
   - The container image for VolSync's rsync-tls-based data mover
 - `rsync-tls.tag`: (current appVersion)
   - The tag to use for the rsync-based data mover

--- a/helm/volsync/values.yaml
+++ b/helm/volsync/values.yaml
@@ -3,39 +3,39 @@ replicaCount: 1
 revisionHistoryLimit: 3
 
 image:
-  repository: quay.io/backube/volsync
+  repository: ghcr.io/perfectra1n/volsync
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   # Directly specifies the SHA hash of the container image to deploy
   image: ""
 rclone:
-  repository: quay.io/backube/volsync
+  repository: ghcr.io/perfectra1n/volsync
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   image: ""
 restic:
-  repository: quay.io/backube/volsync
+  repository: ghcr.io/perfectra1n/volsync
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   image: ""
 rsync:
-  repository: quay.io/backube/volsync
+  repository: ghcr.io/perfectra1n/volsync
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   image: ""
 rsync-tls:
-  repository: quay.io/backube/volsync
+  repository: ghcr.io/perfectra1n/volsync
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   image: ""
 syncthing:
-  repository: quay.io/backube/volsync
+  repository: ghcr.io/perfectra1n/volsync
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   image: ""
 kopia:
-  repository: quay.io/backube/volsync
+  repository: ghcr.io/perfectra1n/volsync
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   image: ""


### PR DESCRIPTION
Fixes #18.  Set each image repository to `repository: ghcr.io/perfectra1n/volsync` and update docs to match.